### PR TITLE
Add vim's temp file (.swp) to global gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.swp
 *.rbc
 *.sassc
 .sass-cache


### PR DESCRIPTION
Just a convenience thing, anyone using vim doesn't want to commit a temp file accidentally.
