### PR TITLE
Fixes #264 - Add per-replay comment user uniqueness constraint

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -7,4 +7,6 @@ class Comment < ActiveRecord::Base
   validates :text,      :presence => true
   validates :replay_id, :presence => true
   validates :user_id,   :presence => true
+
+  validates_uniqueness_of :user_id, :scope => :replay_id, :message => "- You may only comment once on a replay."
 end


### PR DESCRIPTION
With this applied, commenting multiple times on a replay will produce an
error instead of accepting the >1 comments.

The full error message the user gets is "Adding your comment failed: User - You may only comment once on a replay." Some minor hackery can apparently be applied to fully customise the message, but since rails doesn't have the option by default, I haven't tried.

From a UX standpoint, the add comment box should ideally be hidden after making a comment, and/or if you already have a comment posted. I haven't implemented this yet.
